### PR TITLE
Switch decon-spf dependency to patched repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,8 +201,7 @@ checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 [[package]]
 name = "decon-spf"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4af63070d942189cc82a0a2c69480422ec03ee30f6f22e238386e52c0b633a3"
+source = "git+https://github.com/coreequip/rust-decon-spf#47d29e36bba9adbd8e323cb0486e0c30afb381a2"
 dependencies = [
  "ipnetwork",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spf-check"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ anyhow = "1.0.98"
 async-trait = "0.1"
 axum = "0.8.3"
 chrono = "0.4.40"
-decon-spf = "0.3.3"
+# TODO: Use original crate when bugfix is released
+decon-spf = { git = "https://github.com/coreequip/rust-decon-spf" }
 http = "1.3.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.44.2", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ mod spf_checker;
 use crate::spf_checker::{CheckResult, SpfChecker};
 use axum::response::Html;
 use axum::{
-    extract::{Query, State}
-    ,
+    extract::{Query, State},
     http::StatusCode,
     response::{IntoResponse, Json, Response},
     routing::get,


### PR DESCRIPTION
...  while awaiting upstream bugfix.

The patched version is about the [SPF length issue](https://github.com/Bas-Man/rust-decon-spf/issues/6).